### PR TITLE
Flattening of split + CLI + builders + verifiers

### DIFF
--- a/Parser/include/ASTParser.h
+++ b/Parser/include/ASTParser.h
@@ -8,5 +8,6 @@
 namespace RegexParser {
 
 std::unique_ptr<AST::RegExp> parseRegexFromFile(const std::string &regexPath);
+std::unique_ptr<AST::RegExp> parseRegexFromString(const std::string &regexPath);
 
 } // namespace RegexParser

--- a/Parser/src/ASTParser.cpp
+++ b/Parser/src/ASTParser.cpp
@@ -3,20 +3,13 @@
 #include "regexLexer.h"
 #include "regexParser.h"
 #include "visitor/Visitor.h"
+#include <functional>
 
 using namespace std;
 
 namespace RegexParser {
 
-unique_ptr<AST::RegExp> parseRegexFromFile(const string &regexPath) {
-    ifstream stream;
-    stream.open(regexPath);
-
-    if (!stream) {
-        return nullptr;
-    }
-
-    antlr4::ANTLRInputStream input(stream);
+unique_ptr<AST::RegExp> parseRegexImpl(antlr4::ANTLRInputStream input) {
     regexLexer lexer(&input);
     antlr4::CommonTokenStream tokens(&lexer);
 
@@ -25,5 +18,20 @@ unique_ptr<AST::RegExp> parseRegexFromFile(const string &regexPath) {
     regexParser::RegExpContext *regExpTree = parser.root()->regExp();
 
     return move(RegexVisitor().visitRegExp(regExpTree));
+}
+
+unique_ptr<AST::RegExp> parseRegexFromFile(const string &regexPath) {
+
+    ifstream stream;
+    stream.open(regexPath);
+
+    if (!stream) {
+        return nullptr;
+    }
+    return parseRegexImpl(antlr4::ANTLRInputStream(stream));
+}
+
+std::unique_ptr<AST::RegExp> parseRegexFromString(const std::string &regex) {
+    return parseRegexImpl(antlr4::ANTLRInputStream(regex));
 }
 } // namespace RegexParser

--- a/README.md
+++ b/README.md
@@ -23,3 +23,121 @@ cd build
 cmake ..
 cmake --build .
 ```
+
+## Dialect Design
+
+```mlir
+
+// Example: ab|cd
+
+module {
+    "cicero.regionSplit"() ({
+        // Match a
+        "cicero.match_char"() {targetChar = 97 : i8} : () -> ()
+        // Match b
+        "cicero.match_char"() {targetChar = 98 : i8} : () -> ()
+    }) { splitReturn = "SPLIT0_RETURN"} : () -> ()
+
+    // Match c
+    "cicero.match_char"() {targetChar = 99 : i8} : () -> ()
+    // Match d
+    "cicero.match_char"() {targetChar = 100 : i8} : () -> ()
+
+    "cicero.placeholder"() {sym_name = "SPLIT0_RETURN"} : () -> ()
+    "cicero.accept"() : () -> ()
+
+    "cicero.placeholder"() {sym_name = "CICERO_END"} : () -> ()
+}
+
+// Pass to flatten the `regionSplit` into a `targetSplit`
+
+module {
+    // Splits execution between next instruction (match c) and the one
+    // with "SPLIT0_TARGET" symbol
+    "cicero.targetSplit"() {splitTarget = "SPLIT0_TARGET"} : () -> ()
+
+    // Match c
+    "cicero.match_char"() {targetChar = 99 : i8} : () -> ()
+    // Match d
+    "cicero.match_char"() {targetChar = 100 : i8} : () -> ()
+
+    "cicero.placeholder"() {sym_name = "SPLIT0_TARGET"} : () -> ()
+    "cicero.accept"() {} : () -> ()
+    "cicero.placeholder"() {sym_name = "CICERO_END"} : () -> ()
+
+    //// This is the body of SPLIT0
+    // Match a
+    "cicero.match_char"() {sym_name = "SPLIT0_TARGET", targetChar = 97 : i8} : () -> ()
+    // Match b
+    "cicero.match_char"() {targetChar = 98 : i8} : () -> ()
+    // Return
+    "cicero.jump"() {target = "SPLIT0_RETURN"} : () -> ()
+    /// End body of SPLIT0
+
+    "cicero.placeholder"() {sym_name = "CICERO_END"} : () -> ()
+}
+```
+
+## new dialect design
+
+
+```mlir
+
+// Example: (ab|cd)*
+
+"builtin.module"() ({
+  "cicero.split"() ({
+    "cicero.split"() ({
+      "cicero.match_char"() {targetChar = 97 : i8} : () -> ()
+      "cicero.match_char"() {targetChar = 98 : i8} : () -> ()
+      "cicero.jump"() {target = @S1} : () -> ()
+    }) : () -> ()
+    "cicero.match_char"() {targetChar = 99 : i8} : () -> ()
+    "cicero.match_char"() {targetChar = 100 : i8} : () -> ()
+    "cicero.placeholder"() {sym_name = "S1"} : () -> ()
+    "cicero.jump"() {target = @S0} : () -> ()
+  }) {sym_name = "S0"} : () -> ()
+  "cicero.accept"() : () -> ()
+}) : () -> ()
+
+// Flatten the (inner) split
+
+"builtin.module"() ({
+  "cicero.split"() ({
+    "cicero.flatsplit"() {splitTarget = "S2"} : () -> ()
+    "cicero.match_char"() {targetChar = 99 : i8} : () -> ()
+    "cicero.match_char"() {targetChar = 100 : i8} : () -> ()
+    "cicero.placeholder"() {sym_name = "S1"} : () -> ()
+    "cicero.jump"() {target = @S0} : () -> ()
+    // Body of inner split
+    "cicero.placeholder"() {sym_name = "S2"} : () -> ()
+    "cicero.match_char"() {targetChar = 97 : i8} : () -> ()
+    "cicero.match_char"() {targetChar = 98 : i8} : () -> ()
+    "cicero.jump"() {target = @S1} : () -> ()
+    // End body of inner split
+  }) {sym_name = "S0"} : () -> ()
+  "cicero.accept"() : () -> ()
+}) : () -> ()
+
+// Flatten the outer split
+
+"builtin.module"() ({
+  "cicero.flatsplit"() {splitTarget = "S3"} : () -> ()
+  "cicero.accept"() : () -> ()
+  // Body of outer split
+  "cicero.placeholder"() {sym_name = "S3"} : () -> ()
+  "cicero.flatsplit"() {splitTarget = "S2"} : () -> ()
+  "cicero.match_char"() {targetChar = 99 : i8} : () -> ()
+  "cicero.match_char"() {targetChar = 100 : i8} : () -> ()
+  "cicero.placeholder"() {sym_name = "S1"} : () -> ()
+  "cicero.jump"() {target = @S0} : () -> ()
+  // Body of inner split
+  "cicero.placeholder"() {sym_name = "S2"} : () -> ()
+  "cicero.match_char"() {targetChar = 97 : i8} : () -> ()
+  "cicero.match_char"() {targetChar = 98 : i8} : () -> ()
+  "cicero.jump"() {target = @S1} : () -> ()
+  // End body of inner split
+  // End body of outer split
+}) : () -> ()
+
+```

--- a/include/MLIRGenerator.h
+++ b/include/MLIRGenerator.h
@@ -10,8 +10,7 @@ class MLIRGenerator {
   public:
     MLIRGenerator(mlir::MLIRContext &context) : builder(&context){};
 
-    mlir::ModuleOp mlirGen(std::unique_ptr<RegexParser::AST::RegExp> regExp,
-                           bool isRoot = true);
+    mlir::ModuleOp mlirGen(std::unique_ptr<RegexParser::AST::RegExp> regExp);
 
     void populateRegexBody(mlir::Block *block,
                            const RegexParser::AST::RegExp &regExp);
@@ -27,16 +26,17 @@ class MLIRGenerator {
                            const RegexParser::AST::Group &group);
 
     void populateQuantifierOptionalBody(mlir::Block *block,
-                              const RegexParser::AST::Atom &atom);
+                                        const RegexParser::AST::Atom &atom);
 
     void populateQuantifierStarBody(mlir::Block *block,
-                              const RegexParser::AST::Atom &atom);
-    
-    void populateQuantifierPlusBody(mlir::Block *block, 
-                              const RegexParser::AST::Atom &atom);
+                                    const RegexParser::AST::Atom &atom);
+
+    void populateQuantifierPlusBody(mlir::Block *block,
+                                    const RegexParser::AST::Atom &atom);
 
     void populateQuantifierRangeBody(mlir::Block *block,
-                              const RegexParser::AST::Atom &atom, int min, int max);
+                                     const RegexParser::AST::Atom &atom,
+                                     int min, int max);
 
   private:
     mlir::OpBuilder builder;

--- a/src/Passes.cpp
+++ b/src/Passes.cpp
@@ -19,16 +19,17 @@ struct FlattenSplit : public mlir::OpRewritePattern<SplitOp> {
         std::string splitTarget = "FLATTEN_" + std::to_string(symbolCounter++);
 
         rewriter.setInsertionPointToEnd(op.getOperation()->getBlock());
-        auto placeholder = rewriter.create<PlaceholderOp>(op.getLoc());
-        placeholder.setName(splitTarget);
+        rewriter.create<PlaceholderOp>(op.getLoc(), splitTarget);
 
         rewriter.mergeBlocks(op.getBody(), op.getOperation()->getBlock());
+        rewriter.create<JumpOp>(op.getLoc(), op.getSplitReturnAttr());
 
         rewriter.setInsertionPointAfter(op.getOperation());
-        rewriter.replaceOpWithNewOp<FlatSplitOp>(op.getOperation(),
-                                                 splitTarget);
+        auto flatsplitOp = rewriter.replaceOpWithNewOp<FlatSplitOp>(
+            op.getOperation(), splitTarget);
+        flatsplitOp.setName(op.getNameAttr());
 
-        return mlir::failure();
+        return mlir::success();
     }
 };
 

--- a/src/Passes.cpp
+++ b/src/Passes.cpp
@@ -5,20 +5,34 @@
 
 using namespace cicero_compiler::dialect;
 
+unsigned int symbolCounter = 0;
 
-struct RemovePlaceholders : public mlir::OpRewritePattern<PlaceholderOp> {
+struct FlattenSplit : public mlir::OpRewritePattern<SplitOp> {
 
-    RemovePlaceholders(mlir::MLIRContext *context)
+    FlattenSplit(mlir::MLIRContext *context)
         : OpRewritePattern(context, /*benefit=*/100) {}
 
     mlir::LogicalResult
-    matchAndRewrite(PlaceholderOp op,
+    matchAndRewrite(SplitOp op,
                     mlir::PatternRewriter &rewriter) const override {
-        return mlir::LogicalResult::success();
+
+        std::string splitTarget = "FLATTEN_" + std::to_string(symbolCounter++);
+
+        rewriter.setInsertionPointToEnd(op.getOperation()->getBlock());
+        auto placeholder = rewriter.create<PlaceholderOp>(op.getLoc());
+        placeholder.setName(splitTarget);
+
+        rewriter.mergeBlocks(op.getBody(), op.getOperation()->getBlock());
+
+        rewriter.setInsertionPointAfter(op.getOperation());
+        rewriter.replaceOpWithNewOp<FlatSplitOp>(op.getOperation(),
+                                                 splitTarget);
+
+        return mlir::failure();
     }
 };
 
-void cicero_compiler::dialect::PlaceholderOp::getCanonicalizationPatterns(
+void cicero_compiler::dialect::SplitOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
-    results.add<RemovePlaceholders>(context);
+    results.add<FlattenSplit>(context);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,10 +15,9 @@
 using namespace std;
 namespace cl = llvm::cl;
 
-static cl::opt<std::string> inputRegex(cl::Optional,
-                                          "regex",
-                                          cl::desc("<input regex>"),
-                                          cl::value_desc("regex"));
+static cl::opt<std::string> inputRegex(cl::Optional, "regex",
+                                       cl::desc("<input regex>"),
+                                       cl::value_desc("regex"));
 
 static cl::opt<std::string> inputFilename(cl::Positional, cl::Optional,
                                           cl::desc("<input file>"),
@@ -82,6 +81,7 @@ int main(int argc, char **argv) {
     }
 
     mlir::PassManager pm(&context);
+    applyPassManagerCLOptions(pm);
 
     pm.addPass(mlir::createCanonicalizerPass());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,11 @@
 using namespace std;
 namespace cl = llvm::cl;
 
+static cl::opt<std::string> inputRegex(cl::Optional,
+                                          "regex",
+                                          cl::desc("<input regex>"),
+                                          cl::value_desc("regex"));
+
 static cl::opt<std::string> inputFilename(cl::Positional, cl::Optional,
                                           cl::desc("<input file>"),
                                           cl::value_desc("filename"));
@@ -23,8 +28,14 @@ unique_ptr<RegexParser::AST::RegExp> getAST() {
 
     if (inputFilename.getNumOccurrences() == 0) {
         string regex;
+
+        if (inputRegex.getNumOccurrences() > 0) {
+            regex = inputRegex;
+            return RegexParser::parseRegexFromString(regex);
+        }
         cout << "Enter regex: ";
         cin >> regex;
+        cout << endl;
         return RegexParser::parseRegexFromString(regex);
     }
 
@@ -74,11 +85,6 @@ int main(int argc, char **argv) {
 
     pm.addPass(mlir::createCanonicalizerPass());
 
-    // pm.addNestedPass<cicero_compiler::dialect::PlaceholderOp>(
-    //     mlir::createCanonicalizerPass());
-
-    pm.enableStatistics(mlir::PassDisplayMode::Pipeline);
-    pm.enableCrashReproducerGeneration("./reproducer.mlir", false);
     if (mlir::failed(pm.run(module))) {
         module.print(llvm::outs());
         cerr << "Error running canonicalizer pass" << endl;

--- a/src/mlir-dialect/DialectWrapper.cpp
+++ b/src/mlir-dialect/DialectWrapper.cpp
@@ -35,10 +35,39 @@ LogicalResult myLookup(SymbolTableCollection &symbolTable, Operation *op,
 }
 
 LogicalResult JumpOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-    auto symbolName = getTargetAttr().getValue().str();
-
     auto symbol = getTargetAttr();
-    return myLookup(symbolTable, getOperation(), symbol);
+    auto verifyResult = myLookup(symbolTable, getOperation(), symbol);
+    if (failed(verifyResult)) {
+        getOperation()->emitError(
+            "Verification of JumpOp failed: jump target symbol = \"@" +
+            symbol.getValue().str() + "\" not found.");
+    }
+
+    return verifyResult;
+}
+
+LogicalResult SplitOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+    auto symbol = getSplitReturnAttr();
+    auto verifyResult = myLookup(symbolTable, getOperation(), symbol);
+    if (failed(verifyResult)) {
+        getOperation()->emitError(
+            "Verification of SplitOp failed: return symbol = \"@" +
+            symbol.getValue().str() + "\" not found.");
+    }
+
+    return verifyResult;
+}
+
+LogicalResult FlatSplitOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+    auto symbol = getSplitTargetAttr();
+    auto verifyResult = myLookup(symbolTable, getOperation(), symbol);
+    if (failed(verifyResult)) {
+        getOperation()->emitError(
+            "Verification of FlatSplitOp failed: split target symbol = \"@" +
+            symbol.getValue().str() + "\" not found.");
+    }
+
+    return verifyResult;
 }
 
 #define GET_OP_CLASSES

--- a/src/mlir-dialect/Ops.td
+++ b/src/mlir-dialect/Ops.td
@@ -39,8 +39,8 @@ def SplitOp : Cicero_Op<"split", [Symbol, SymbolTable]> {
     let summary = "Splits the thread of execution into two";
     let description = [{
         The thread is split into two threads:
-        - one continues at the next instruction
-        - the other one continues at the split body (its entry block)
+        - one continues at the next operation
+        - the other one continues at the **split body** (its entry block)
     }];
 
     let regions = (region AnyRegion:$splittedThread);
@@ -60,6 +60,19 @@ def SplitOp : Cicero_Op<"split", [Symbol, SymbolTable]> {
 
         bool isOptionalSymbol() { return true; }
     }];
+
+    let hasCanonicalizer = 1;
+}
+
+def FlatSplitOp : Cicero_Op<"flat_split"> {
+    let summary = "Splits the thread of execution into two";
+    let description = [{
+        The thread is split into two threads:
+        - one continues at the next operation
+        - the other one continues at operation referenced by the splitTarget attribute
+    }];
+
+    let arguments = (ins FlatSymbolRefAttr:$splitTarget);
 }
 
 def JumpOp : Cicero_Op<"jump", [DeclareOpInterfaceMethods<SymbolUserOpInterface>, Terminator]> {
@@ -102,8 +115,6 @@ def PlaceholderOp : Cicero_Op<"placeholder", [Symbol]> {
     let description = [{
         Placeholder operation, only used internally by the compiler to represent jump/split targets.
     }];
-
-    let hasCanonicalizer = 1;
 }
 
 #endif // CICERO_DIALECT_H

--- a/src/mlir-dialect/Ops.td
+++ b/src/mlir-dialect/Ops.td
@@ -35,21 +35,23 @@ def AcceptPartialOp : Cicero_Op<"accept_partial"> {
     }];
 }
 
-def SplitOp : Cicero_Op<"split", [Symbol, SymbolTable]> {
+def SplitOp : Cicero_Op<"split", [Symbol, SymbolTable, NoTerminator, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
     let summary = "Splits the thread of execution into two";
     let description = [{
         The thread is split into two threads:
         - one continues at the next operation
-        - the other one continues at the **split body** (its entry block)
+        - the other one continues at the **split body** (its entry block), at the end of it it jumps to splitReturn
     }];
 
     let regions = (region AnyRegion:$splittedThread);
 
+    let arguments = (ins FlatSymbolRefAttr:$splitReturn);
+
     let builders = [
-        OpBuilder<(ins), [{
-            // build($_builder, $_state);
+        OpBuilder<(ins "std::string":$returnSymbol), [{
             $_state.addRegion();
             $_state.regions[0]->push_back(new Block());
+            $_state.addAttribute(getSplitReturnAttrName($_state.name), ::mlir::SymbolRefAttr::get($_builder.getContext(), returnSymbol));
         }]>
     ];
 
@@ -64,7 +66,7 @@ def SplitOp : Cicero_Op<"split", [Symbol, SymbolTable]> {
     let hasCanonicalizer = 1;
 }
 
-def FlatSplitOp : Cicero_Op<"flat_split"> {
+def FlatSplitOp : Cicero_Op<"flat_split", [Symbol, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
     let summary = "Splits the thread of execution into two";
     let description = [{
         The thread is split into two threads:
@@ -73,9 +75,13 @@ def FlatSplitOp : Cicero_Op<"flat_split"> {
     }];
 
     let arguments = (ins FlatSymbolRefAttr:$splitTarget);
+
+    let extraClassDeclaration = [{
+        bool isOptionalSymbol() { return true; }
+    }];
 }
 
-def JumpOp : Cicero_Op<"jump", [DeclareOpInterfaceMethods<SymbolUserOpInterface>, Terminator]> {
+def JumpOp : Cicero_Op<"jump", [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
     let summary = "Unconditionally jumps to argument";
     let description = [{
         The thread continues at the instruction specified by the argument as a symbol reference.
@@ -115,6 +121,13 @@ def PlaceholderOp : Cicero_Op<"placeholder", [Symbol]> {
     let description = [{
         Placeholder operation, only used internally by the compiler to represent jump/split targets.
     }];
+
+    let builders = [
+        OpBuilder<(ins "std::string":$symbol), [{
+            $_state.addAttribute(SymbolTable::getSymbolAttrName(),
+                        $_builder.getStringAttr(symbol));
+        }]>
+    ];
 }
 
 #endif // CICERO_DIALECT_H


### PR DESCRIPTION
# Split flattening

```mlir
"cicero.split"() ({
  "cicero.match_char"() {targetChar = 97 : i8} : () -> ()
}) {splitReturn = @S1} : () -> ()

[...]

"cicero.placeholder"() {sym_name = "S1"} : () -> ()
```

becomes:

```mlir
"cicero.flat_split"() {splitTarget = @FLATTEN_0} : () -> ()

[...]

"cicero.placeholder"() {sym_name = "S1"} : () -> ()

[...]
"cicero.placeholder"() {sym_name = "FLATTEN_0"} : () -> ()
"cicero.match_char"() {targetChar = 97 : i8} : () -> ()
"cicero.jump"() {target = @S1} : () -> ()
```

# Other

1. Parse a regex passed by CLI (`./main --regex "abc|def"`)
2. Better builder for non-optional Symbol Ops (e.g. placeholder), now we can set the symbol name at creation
3. Verification of all symbol users for symbol existance using `SymbolUserOpInterface`