### PR TITLE
Option to dump MLIR into graphviz format

### DIFF
--- a/include/cicero_const.h
+++ b/include/cicero_const.h
@@ -13,4 +13,4 @@ enum CiceroOpCodes {
 
 enum CiceroBinaryOutputFormat { Binary, Hex };
 
-enum CiceroAction { None, DumpAST, DumpMLIR, DumpCompiled };
+enum CiceroAction { None, DumpAST, DumpMLIR, DumpDOT, DumpCompiled };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,7 +206,7 @@ int main(int argc, char **argv) {
                                 jumpTargetIndex, false);
             } else {
                 throw std::runtime_error(
-                    "Code generation for operation not implemented: " +
+                    "Graphviz output for operation not implemented: " +
                     op->getName().getStringRef().str());
             }
             operationIndex++;


### PR DESCRIPTION
Added a new CLI `--emit=mlir.dot` option that dumps MLIR into graphviz format.

For example, `ab|cd|ef(gh)*` outputs this:

```
digraph {
0 [label="Split"];
0 -> 1;
0 -> 7;
1 [label="Split"];
1 -> 2;
1 -> 9;
2 [label="Split"];
2 -> 3;
2 -> 12;
3 [label="MatchChar: e"];
3 -> 4;
4 [label="MatchChar: f"];
4 -> 5;
5 [label="Split"];
5 -> 6;
5 -> 15;
6 [label="AcceptPartial"];
7 [label="MatchAny"];
7 -> 8;
8 [label="Jump"];
8 -> 0;
9 [label="MatchChar: a"];
9 -> 10;
10 [label="MatchChar: b"];
10 -> 11;
11 [label="AcceptPartial"];
12 [label="MatchChar: c"];
12 -> 13;
13 [label="MatchChar: d"];
13 -> 14;
14 [label="AcceptPartial"];
15 [label="MatchChar: g"];
15 -> 16;
16 [label="MatchChar: h"];
16 -> 17;
17 [label="Jump"];
17 -> 5;
}
```

which graphically is this:

![image](https://github.com/thegoldgoat/cicero_compiler_cpp/assets/25644731/a508e050-184b-4cf9-93df-47da01c15720)
