### PR TITLE
Regular Expression optimization for same-prefix alternation

### DIFF
--- a/Parser/CMakeLists.txt
+++ b/Parser/CMakeLists.txt
@@ -135,6 +135,7 @@ add_library(
         ${PROJECT_SOURCE_DIR}/src/RegexDialectWrapper.cpp
         ${PROJECT_BINARY_DIR}/include/metachars.h
         src/visitor/MLIRVisitor.cpp
+        src/MLIRRegexOptimization.cpp
 )
 
 add_dependencies(

--- a/Parser/examples/5.txt
+++ b/Parser/examples/5.txt
@@ -1,0 +1,1 @@
+this|that

--- a/Parser/examples/6.txt
+++ b/Parser/examples/6.txt
@@ -1,0 +1,1 @@
+cane|cane

--- a/Parser/examples/7.txt
+++ b/Parser/examples/7.txt
@@ -1,0 +1,1 @@
+canex|cane

--- a/Parser/include/MLIRParser.h
+++ b/Parser/include/MLIRParser.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "MLIRRegexOptimization.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include <string>
@@ -7,8 +8,11 @@
 namespace RegexParser {
 
 mlir::ModuleOp parseRegexFromFile(mlir::MLIRContext &context,
-                                  const std::string &regexPath);
+                                  const std::string &regexPath,
+                                  bool printFileToStdout = false);
 mlir::ModuleOp parseRegexFromString(mlir::MLIRContext &context,
                                     const std::string &regex);
+
+mlir::LogicalResult optimizeRegex(mlir::ModuleOp &module);
 
 } // namespace RegexParser

--- a/Parser/include/MLIRParser.h
+++ b/Parser/include/MLIRParser.h
@@ -9,7 +9,7 @@ namespace RegexParser {
 
 mlir::ModuleOp parseRegexFromFile(mlir::MLIRContext &context,
                                   const std::string &regexPath,
-                                  bool printFileToStdout = false);
+                                  bool printFileToStdout = true);
 mlir::ModuleOp parseRegexFromString(mlir::MLIRContext &context,
                                     const std::string &regex);
 

--- a/Parser/include/MLIRRegexOptimization.h
+++ b/Parser/include/MLIRRegexOptimization.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "RegexDialectWrapper.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+
+namespace RegexParser::passes {
+
+#define DEFINE_REWRITE_PATTERN_MACRO(patternName, opName)                            \
+    struct patternName : public mlir::OpRewritePattern<opName> {               \
+        patternName(mlir::MLIRContext *context) : OpRewritePattern(context) {} \
+        mlir::LogicalResult                                                    \
+        matchAndRewrite(opName op,                                             \
+                        mlir::PatternRewriter &rewriter) const override;       \
+    }
+
+/*
+ * Factorization 
+*/
+
+DEFINE_REWRITE_PATTERN_MACRO(FactorizeRoot, RegexParser::dialect::RootOp);
+DEFINE_REWRITE_PATTERN_MACRO(FactorizeSubregex, RegexParser::dialect::SubRegexOp);
+
+} // namespace RegexParser::passes

--- a/Parser/src/MLIRParser.cpp
+++ b/Parser/src/MLIRParser.cpp
@@ -40,7 +40,7 @@ mlir::ModuleOp parseRegexFromFile(mlir::MLIRContext &context,
     if (printFileToStdout) {
         cout << "--- FILE CONTENTS ---\n";
         cout << stream.rdbuf();
-        cout << "--- END FILE      ---\n";
+        cout << "\n--- END FILE      ---\n";
     }
 
     stream.seekg(0, ios::beg);

--- a/Parser/src/MLIRRegexOptimization.cpp
+++ b/Parser/src/MLIRRegexOptimization.cpp
@@ -1,0 +1,154 @@
+#include "MLIRRegexOptimization.h"
+#include <vector>
+
+// #include "mlir-dialect/MyOperationEquivalence.h"
+#include "mlir/IR/OperationSupport.h"
+
+using namespace std;
+
+namespace RegexParser::passes {
+
+mlir::LogicalResult optimizeCommonPrefix(mlir::Operation *op,
+                                         mlir::PatternRewriter &rewriter);
+template <typename OpT>
+mlir::LogicalResult checkAllOpInVectorAreEqual(vector<OpT> &ops);
+
+mlir::LogicalResult
+FactorizeRoot::matchAndRewrite(RegexParser::dialect::RootOp op,
+                               mlir::PatternRewriter &rewriter) const {
+    return optimizeCommonPrefix(op.getOperation(), rewriter);
+}
+
+mlir::LogicalResult
+FactorizeSubregex::matchAndRewrite(RegexParser::dialect::SubRegexOp op,
+                                   mlir::PatternRewriter &rewriter) const {
+    op == op;
+    return optimizeCommonPrefix(op.getOperation(), rewriter);
+}
+
+mlir::LogicalResult optimizeCommonPrefix(mlir::Operation *op,
+                                         mlir::PatternRewriter &rewriter) {
+    mlir::Block &opBlock = op->getRegion(0).front();
+    vector<dialect::ConcatenationOp> concatenations;
+    concatenations.reserve(10);
+    vector<dialect::PieceOp> piecesWalkers;
+    piecesWalkers.reserve(10);
+
+    for (auto &op : opBlock) {
+        if (auto concat = mlir::dyn_cast<dialect::ConcatenationOp>(op)) {
+            auto &maybePieceOp = concat.getBody()->front();
+            if (auto pieceOp = mlir::dyn_cast<dialect::PieceOp>(maybePieceOp)) {
+                piecesWalkers.emplace_back(std::move(pieceOp));
+            } else {
+                throw runtime_error(
+                    "optimizeCommonPrefix: expected to find PieceOp within "
+                    "ConcatenationOp, but found " +
+                    maybePieceOp.getName().getStringRef().str());
+            }
+            concatenations.emplace_back(std::move(concat));
+        } else {
+            throw runtime_error("optimizeCommonPrefix: block must contain only "
+                                "concatenation operations, found " +
+                                op.getName().getStringRef().str());
+        }
+    }
+
+    // We need at least two concatenations to factorize
+    if (concatenations.size() < 2) {
+        return mlir::failure();
+    }
+
+    unsigned int piecesWalked = 0;
+    while (true) {
+        // Check all pieces are the same
+        if (checkAllOpInVectorAreEqual<dialect::PieceOp>(piecesWalkers)
+                .succeeded()) {
+            piecesWalked++;
+            for (size_t i = 0; i < piecesWalkers.size(); i++) {
+                auto nextNode = piecesWalkers[i].getOperation()->getNextNode();
+                if (nextNode == nullptr) {
+                    // TODO: Check that also all the other ones are at the end
+                    // of the block
+
+                    // We reached the end of the block! Remove all the
+                    // concatenations except the first one
+                    for (size_t j = 1; j < concatenations.size(); j++) {
+                        rewriter.eraseOp(concatenations[j].getOperation());
+                    }
+                    return mlir::success();
+                }
+                auto nextPiece = mlir::dyn_cast<dialect::PieceOp>(nextNode);
+                if (nextPiece) {
+                    piecesWalkers[i] = nextPiece;
+                } else {
+                    throw std::runtime_error(
+                        "optimizeCommonPrefix: expected to find PieceOp after "
+                        "PieceOp, but found " +
+                        piecesWalkers[i]
+                            .getOperation()
+                            ->getNextNode()
+                            ->getName()
+                            .getStringRef()
+                            .str());
+                }
+            }
+        } else {
+            break;
+        }
+    }
+
+    if (piecesWalked == 0) {
+        return mlir::failure();
+    }
+
+    // Get the first `piecesWalked` pieces from the any concatenation (e.g. the
+    // first) and put them in a new ConcatenationOp, at the beginning of
+    // `opBlock`. Then, remove the first `piecesWalked` pieces from all the
+    // other concatenations.
+
+    rewriter.setInsertionPointToStart(&opBlock);
+    auto newConcatenation =
+        rewriter.create<dialect::ConcatenationOp>(rewriter.getUnknownLoc());
+    auto newConcatenationBody = newConcatenation.getBody();
+    rewriter.setInsertionPointToStart(newConcatenationBody);
+
+    size_t piecesAlreadyMoved = 0;
+    for (auto &op : concatenations[0].getBody()->getOperations()) {
+        rewriter.clone(op);
+        piecesAlreadyMoved++;
+        if (piecesAlreadyMoved == piecesWalked) {
+            break;
+        }
+    }
+
+    for (auto &concatenation : concatenations) {
+        for (size_t i = 0; i < piecesWalked; i++) {
+            rewriter.eraseOp(&concatenation.getBody()->front());
+        }
+    }
+
+    return mlir::success();
+}
+template <typename OpT>
+mlir::LogicalResult checkAllOpInVectorAreEqual(vector<OpT> &ops) {
+    assert(ops.size() > 0);
+    if (ops.size() == 1) {
+        return mlir::success();
+    }
+
+    auto &firstOp = ops[0];
+    auto equivalenceFlags = mlir::OperationEquivalence::Flags::IgnoreLocations;
+    for (size_t i = 1; i < ops.size(); i++) {
+        if (false == mlir::OperationEquivalence::isEquivalentTo(
+                         ops[i].getOperation(), firstOp.getOperation(),
+                         mlir::OperationEquivalence::ignoreValueEquivalence,
+                         mlir::OperationEquivalence::ignoreValueEquivalence,
+                         equivalenceFlags)) {
+            return mlir::failure();
+        }
+    }
+
+    return mlir::success();
+}
+
+} // namespace RegexParser::passes


### PR DESCRIPTION
Closes #4

Works when an alternation (both in root of regex, or in subregex) has concatenation that all have same prefix, for example:

```
❯ ./mlirdumper --regex "this|that"
--- MODULE BEFORE OPTIMIZATION ---

"builtin.module"() ({
  "regex.root"() ({
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 116 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 104 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 105 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 115 : i8} : () -> ()
      }) : () -> ()
    }) : () -> ()
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 116 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 104 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 97 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 116 : i8} : () -> ()
      }) : () -> ()
    }) : () -> ()
  }) {hasPrefix = true, hasSuffix = true} : () -> ()
}) : () -> ()


--- MODULE AFTER OPTIMIZATION ---

"builtin.module"() ({
  "regex.root"() ({
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 116 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 104 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.sub_regex"() ({
          "regex.concatenation"() ({
            "regex.piece"() ({
              "regex.match_char"() {targetChar = 105 : i8} : () -> ()
            }) : () -> ()
            "regex.piece"() ({
              "regex.match_char"() {targetChar = 115 : i8} : () -> ()
            }) : () -> ()
          }) : () -> ()
          "regex.concatenation"() ({
            "regex.piece"() ({
              "regex.match_char"() {targetChar = 97 : i8} : () -> ()
            }) : () -> ()
            "regex.piece"() ({
              "regex.match_char"() {targetChar = 116 : i8} : () -> ()
            }) : () -> ()
          }) : () -> ()
        }) : () -> ()
      }) : () -> ()
    }) : () -> ()
  }) {hasPrefix = true, hasSuffix = true} : () -> ()
}) : () -> ()
```

Or also:

```
❯ ./mlirdumper --regex "this|th"
--- MODULE BEFORE OPTIMIZATION ---

"builtin.module"() ({
  "regex.root"() ({
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 116 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 104 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 105 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 115 : i8} : () -> ()
      }) : () -> ()
    }) : () -> ()
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 116 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 104 : i8} : () -> ()
      }) : () -> ()
    }) : () -> ()
  }) {hasPrefix = true, hasSuffix = true} : () -> ()
}) : () -> ()


--- MODULE AFTER OPTIMIZATION ---

"builtin.module"() ({
  "regex.root"() ({
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 116 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 104 : i8} : () -> ()
      }) : () -> ()
      "regex.piece"() ({
        "regex.sub_regex"() ({
          "regex.concatenation"() ({
            "regex.piece"() ({
              "regex.match_char"() {targetChar = 105 : i8} : () -> ()
            }) : () -> ()
            "regex.piece"() ({
              "regex.match_char"() {targetChar = 115 : i8} : () -> ()
            }) : () -> ()
          }) : () -> ()
        }) : () -> ()
        "regex.quantifier"() {max = 1 : si64, min = 0 : si64} : () -> ()
      }) : () -> ()
    }) : () -> ()
  }) {hasPrefix = true, hasSuffix = true} : () -> ()
}) : () -> ()
```

Note that it does not work in cases where some (even one out of many!) of the concatenations have a different prefix, for example:

```
❯ ./mlirdumper --regex "A|A|B"
--- MODULE BEFORE OPTIMIZATION ---

"builtin.module"() ({
  "regex.root"() ({
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 65 : i8} : () -> ()
      }) : () -> ()
    }) : () -> ()
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 65 : i8} : () -> ()
      }) : () -> ()
    }) : () -> ()
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 66 : i8} : () -> ()
      }) : () -> ()
    }) : () -> ()
  }) {hasPrefix = true, hasSuffix = true} : () -> ()
}) : () -> ()


--- MODULE AFTER OPTIMIZATION ---

"builtin.module"() ({
  "regex.root"() ({
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 65 : i8} : () -> ()
      }) : () -> ()
    }) : () -> ()
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 65 : i8} : () -> ()
      }) : () -> ()
    }) : () -> ()
    "regex.concatenation"() ({
      "regex.piece"() ({
        "regex.match_char"() {targetChar = 66 : i8} : () -> ()
      }) : () -> ()
    }) : () -> ()
  }) {hasPrefix = true, hasSuffix = true} : () -> ()
}) : () -> ()
```